### PR TITLE
Use relative imports within chexfound package

### DIFF
--- a/chexfound/data/samplers.py
+++ b/chexfound/data/samplers.py
@@ -11,7 +11,7 @@ import numpy as np
 import torch
 from torch.utils.data.sampler import Sampler
 
-import chexfound.distributed as distributed
+from .. import distributed
 
 
 class EpochSampler(Sampler):

--- a/chexfound/data/wrappers.py
+++ b/chexfound/data/wrappers.py
@@ -1,7 +1,7 @@
 import torch
 import numpy as np
-from chexfound.data.utils import get_fewshot_in_nih
-from chexfound.data.datasets import NIHChestXray
+from .utils import get_fewshot_in_nih
+from .datasets import NIHChestXray
 
 class FewShotDatasetWrapper(torch.utils.data.Subset):
     def __init__(self, dataset, shots=16):

--- a/chexfound/eval/classification/knn.py
+++ b/chexfound/eval/classification/knn.py
@@ -14,13 +14,13 @@ from typing import List, Optional
 import torch
 from torch.nn.functional import one_hot, softmax
 
-import chexfound.distributed as distributed
-from chexfound.data import SamplerType, make_data_loader, make_dataset
-from chexfound.data.transforms import make_classification_eval_transform
-from chexfound.eval.metrics import AccuracyAveraging, build_topk_accuracy_metric
-from chexfound.eval.setup import get_args_parser as get_setup_args_parser
-from chexfound.eval.setup import setup_and_build_model
-from chexfound.eval.utils import ModelWithNormalize, evaluate, extract_features
+from ... import distributed
+from ...data import SamplerType, make_data_loader, make_dataset
+from ...data.transforms import make_classification_eval_transform
+from ..metrics import AccuracyAveraging, build_topk_accuracy_metric
+from ..setup import get_args_parser as get_setup_args_parser
+from ..setup import setup_and_build_model
+from ..utils import ModelWithNormalize, evaluate, extract_features
 
 
 logger = logging.getLogger("chexfound")

--- a/chexfound/eval/classification/linear_glori.py
+++ b/chexfound/eval/classification/linear_glori.py
@@ -23,25 +23,35 @@ import torch.distributed as dist
 from fvcore.common.checkpoint import Checkpointer, PeriodicCheckpointer
 import pandas as pd
 
-from chexfound.data import SamplerType, make_data_loader, make_dataset
-from chexfound.data.transforms import make_classification_eval_transform, make_classification_train_transform
-import chexfound.distributed as distributed
-from chexfound.eval.metrics import MetricType, build_metric
-from chexfound.eval.setup import get_args_parser as get_setup_args_parser
-from chexfound.eval.setup import setup_and_build_model
-from chexfound.eval.utils import (ModelWithIntermediateLayers, evaluate, apply_method_to_nested_values,
-                                  make_datasets, make_data_loaders, extract_hyperparameters_from_model,
-                                  is_padded_matrix, collate_fn_3d, str2bool, trainable_parameters, bitfit,
-                                  evaluate_preds)
-from chexfound.eval.classification.utils import (setup_linear_classifiers, setup_glori, LinearPostprocessor)
-from chexfound.logging import MetricLogger
-from chexfound.data.wrappers import FewShotDatasetWrapper, SystemicSamplerWrapper
-from chexfound.models.vision_transformer import DinoVisionTransformer
+from ...data import SamplerType, make_data_loader, make_dataset
+from ...data.transforms import make_classification_eval_transform, make_classification_train_transform
+from ... import distributed
+from ..metrics import MetricType, build_metric
+from ..setup import get_args_parser as get_setup_args_parser
+from ..setup import setup_and_build_model
+from ..utils import (
+    ModelWithIntermediateLayers,
+    evaluate,
+    apply_method_to_nested_values,
+    make_datasets,
+    make_data_loaders,
+    extract_hyperparameters_from_model,
+    is_padded_matrix,
+    collate_fn_3d,
+    str2bool,
+    trainable_parameters,
+    bitfit,
+    evaluate_preds,
+)
+from .utils import setup_linear_classifiers, setup_glori, LinearPostprocessor
+from ...logging import MetricLogger
+from ...data.wrappers import FewShotDatasetWrapper, SystemicSamplerWrapper
+from ...models.vision_transformer import DinoVisionTransformer
 
 from peft import LoraConfig, get_peft_model
-from chexfound.eval.losses import AsymmetricLoss
+from ..losses import AsymmetricLoss
 
-from chexfound.data.datasets import CXRLT
+from ...data.datasets import CXRLT
 
 logger = logging.getLogger("chexfound")
 

--- a/chexfound/eval/classification/utils.py
+++ b/chexfound/eval/classification/utils.py
@@ -2,10 +2,10 @@ import numpy as np
 import torch
 import torch.nn as nn
 
-from chexfound.eval.utils import Model3DWrapper
-import chexfound.distributed as distributed
+from ..utils import Model3DWrapper
+from ... import distributed
 
-from chexfound.eval.classification.glori import GLoRI, create_mldecoder_input
+from .glori import GLoRI, create_mldecoder_input
 
 def create_linear_input(x_tokens_list, use_n_blocks, use_avgpool):
     intermediate_output = x_tokens_list[-use_n_blocks:]

--- a/chexfound/eval/knn.py
+++ b/chexfound/eval/knn.py
@@ -14,13 +14,13 @@ from typing import List, Optional
 import torch
 from torch.nn.functional import one_hot, softmax
 
-import chexfound.distributed as distributed
-from chexfound.data import SamplerType, make_data_loader, make_dataset
-from chexfound.data.transforms import make_classification_eval_transform
-from chexfound.eval.metrics import AccuracyAveraging, build_topk_accuracy_metric
-from chexfound.eval.setup import get_args_parser as get_setup_args_parser
-from chexfound.eval.setup import setup_and_build_model
-from chexfound.eval.utils import ModelWithNormalize, evaluate, extract_features
+from .. import distributed
+from ..data import SamplerType, make_data_loader, make_dataset
+from ..data.transforms import make_classification_eval_transform
+from .metrics import AccuracyAveraging, build_topk_accuracy_metric
+from .setup import get_args_parser as get_setup_args_parser
+from .setup import setup_and_build_model
+from .utils import ModelWithNormalize, evaluate, extract_features
 
 
 logger = logging.getLogger("chexfound")

--- a/chexfound/eval/linear.py
+++ b/chexfound/eval/linear.py
@@ -17,14 +17,14 @@ import torch.nn as nn
 from torch.nn.parallel import DistributedDataParallel
 from fvcore.common.checkpoint import Checkpointer, PeriodicCheckpointer
 
-from chexfound.data import SamplerType, make_data_loader, make_dataset
-from chexfound.data.transforms import make_classification_eval_transform, make_classification_train_transform
-import chexfound.distributed as distributed
-from chexfound.eval.metrics import MetricType, build_metric
-from chexfound.eval.setup import get_args_parser as get_setup_args_parser
-from chexfound.eval.setup import setup_and_build_model
-from chexfound.eval.utils import ModelWithIntermediateLayers, evaluate
-from chexfound.logging import MetricLogger
+from ..data import SamplerType, make_data_loader, make_dataset
+from ..data.transforms import make_classification_eval_transform, make_classification_train_transform
+from .. import distributed
+from .metrics import MetricType, build_metric
+from .setup import get_args_parser as get_setup_args_parser
+from .setup import setup_and_build_model
+from .utils import ModelWithIntermediateLayers, evaluate
+from ..logging import MetricLogger
 
 
 logger = logging.getLogger("chexfound")

--- a/chexfound/eval/log_regression.py
+++ b/chexfound/eval/log_regression.py
@@ -18,14 +18,14 @@ from torch import nn
 from torch.utils.data import TensorDataset
 from torchmetrics import MetricTracker
 
-from chexfound.data import make_dataset
-from chexfound.data.transforms import make_classification_eval_transform
-from chexfound.distributed import get_global_rank, get_global_size
-from chexfound.eval.metrics import MetricType, build_metric
-from chexfound.eval.setup import get_args_parser as get_setup_args_parser
-from chexfound.eval.setup import setup_and_build_model
-from chexfound.eval.utils import evaluate, extract_features
-from chexfound.utils.dtype import as_torch_dtype
+from ..data import make_dataset
+from ..data.transforms import make_classification_eval_transform
+from ..distributed import get_global_rank, get_global_size
+from .metrics import MetricType, build_metric
+from .setup import get_args_parser as get_setup_args_parser
+from .setup import setup_and_build_model
+from .utils import evaluate, extract_features
+from ..utils.dtype import as_torch_dtype
 
 
 logger = logging.getLogger("chexfound")

--- a/chexfound/eval/setup.py
+++ b/chexfound/eval/setup.py
@@ -9,9 +9,9 @@ from typing import Any, List, Optional, Tuple
 import torch
 import torch.backends.cudnn as cudnn
 
-from chexfound.models import build_model_from_cfg
-from chexfound.utils.config import setup
-import chexfound.utils.utils as dinov2_utils
+from ..models import build_model_from_cfg
+from ..utils.config import setup
+from ..utils import utils as dinov2_utils
 
 def get_args_parser(
     description: Optional[str] = None,

--- a/chexfound/eval/utils.py
+++ b/chexfound/eval/utils.py
@@ -22,9 +22,9 @@ from torch import nn
 import torchvision
 from torchmetrics import MetricCollection
 
-from chexfound.data import DatasetWithEnumeratedTargets, SamplerType, make_data_loader, make_dataset
-import chexfound.distributed as distributed
-from chexfound.logging import MetricLogger
+from ..data import DatasetWithEnumeratedTargets, SamplerType, make_data_loader, make_dataset
+from .. import distributed
+from ..logging import MetricLogger
 
 logger = logging.getLogger("chexfound")
 

--- a/chexfound/fsdp/__init__.py
+++ b/chexfound/fsdp/__init__.py
@@ -7,7 +7,7 @@ import os
 from typing import Any
 
 import torch
-import chexfound.distributed as distributed
+from .. import distributed
 from functools import partial
 from fvcore.common.checkpoint import Checkpointer
 from torch.distributed.fsdp import FullyShardedDataParallel as FSDP

--- a/chexfound/logging/__init__.py
+++ b/chexfound/logging/__init__.py
@@ -9,7 +9,7 @@ import os
 import sys
 from typing import Optional
 
-import chexfound.distributed as distributed
+from .. import distributed
 from .helpers import MetricLogger, SmoothedValue
 
 

--- a/chexfound/logging/helpers.py
+++ b/chexfound/logging/helpers.py
@@ -11,7 +11,7 @@ import time
 
 import torch
 
-import chexfound.distributed as distributed
+from .. import distributed
 
 
 logger = logging.getLogger("chexfound")

--- a/chexfound/models/vision_transformer.py
+++ b/chexfound/models/vision_transformer.py
@@ -17,7 +17,7 @@ import torch.nn as nn
 import torch.utils.checkpoint
 from torch.nn.init import trunc_normal_
 
-from chexfound.layers import Mlp, PatchEmbed, SwiGLUFFNFused, MemEffAttention, NestedTensorBlock as Block
+from ..layers import Mlp, PatchEmbed, SwiGLUFFNFused, MemEffAttention, NestedTensorBlock as Block
 
 
 logger = logging.getLogger("chexfound")

--- a/chexfound/run/eval/knn.py
+++ b/chexfound/run/eval/knn.py
@@ -7,9 +7,9 @@ import logging
 import os
 import sys
 
-from chexfound.eval.knn import get_args_parser as get_knn_args_parser
-from chexfound.logging import setup_logging
-from chexfound.run.submit import get_args_parser, submit_jobs
+from ...eval.knn import get_args_parser as get_knn_args_parser
+from ...logging import setup_logging
+from ..submit import get_args_parser, submit_jobs
 
 
 logger = logging.getLogger("chexfound")
@@ -20,7 +20,7 @@ class Evaluator:
         self.args = args
 
     def __call__(self):
-        from chexfound.eval.knn import main as knn_main
+        from ...eval.knn import main as knn_main
 
         self._setup_args()
         knn_main(self.args)

--- a/chexfound/run/eval/linear.py
+++ b/chexfound/run/eval/linear.py
@@ -7,9 +7,9 @@ import logging
 import os
 import sys
 
-from chexfound.eval.classification.linear_glori import get_args_parser as get_linear_args_parser
-from chexfound.logging import setup_logging
-from chexfound.run.submit import get_args_parser, submit_jobs
+from ...eval.classification.linear_glori import get_args_parser as get_linear_args_parser
+from ...logging import setup_logging
+from ..submit import get_args_parser, submit_jobs
 
 
 logger = logging.getLogger("chexfound")
@@ -20,7 +20,7 @@ class Evaluator:
         self.args = args
 
     def __call__(self):
-        from chexfound.eval.classification.linear_glori import main as linear_main
+        from ...eval.classification.linear_glori import main as linear_main
 
         self._setup_args()
         linear_main(self.args)

--- a/chexfound/run/eval/log_regression.py
+++ b/chexfound/run/eval/log_regression.py
@@ -7,9 +7,9 @@ import logging
 import os
 import sys
 
-from chexfound.eval.log_regression import get_args_parser as get_log_regression_args_parser
-from chexfound.logging import setup_logging
-from chexfound.run.submit import get_args_parser, submit_jobs
+from ...eval.log_regression import get_args_parser as get_log_regression_args_parser
+from ...logging import setup_logging
+from ..submit import get_args_parser, submit_jobs
 
 
 logger = logging.getLogger("chexfound")
@@ -20,7 +20,7 @@ class Evaluator:
         self.args = args
 
     def __call__(self):
-        from chexfound.eval.log_regression import main as log_regression_main
+        from ...eval.log_regression import main as log_regression_main
 
         self._setup_args()
         log_regression_main(self.args)

--- a/chexfound/run/submit.py
+++ b/chexfound/run/submit.py
@@ -11,7 +11,7 @@ from typing import List, Optional
 
 import submitit
 
-from chexfound.utils.cluster import (
+from ..utils.cluster import (
     get_slurm_executor_parameters,
     get_slurm_partition,
     get_user_checkpoint_path,

--- a/chexfound/run/train/train.py
+++ b/chexfound/run/train/train.py
@@ -7,9 +7,9 @@ import logging
 import os
 import sys
 
-from chexfound.logging import setup_logging
-from chexfound.train import get_args_parser as get_train_args_parser
-from chexfound.run.submit import get_args_parser, submit_jobs
+from ...logging import setup_logging
+from ...train import get_args_parser as get_train_args_parser
+from ..submit import get_args_parser, submit_jobs
 
 
 logger = logging.getLogger("chexfound")
@@ -20,7 +20,7 @@ class Trainer(object):
         self.args = args
 
     def __call__(self):
-        from chexfound.train import main as train_main
+        from ...train import main as train_main
 
         self._setup_args()
         train_main(self.args)

--- a/chexfound/train/ssl_meta_arch.py
+++ b/chexfound/train/ssl_meta_arch.py
@@ -9,14 +9,14 @@ import logging
 import torch
 from torch import nn
 
-from chexfound.loss import DINOLoss, iBOTPatchLoss, KoLeoLoss
-from chexfound.models import build_model_from_cfg
-from chexfound.layers import DINOHead
-from chexfound.utils.utils import has_batchnorms
-from chexfound.utils.param_groups import get_params_groups_with_decay, fuse_params_groups
-from chexfound.fsdp import get_fsdp_wrapper, ShardedGradScaler, get_fsdp_modules, reshard_fsdp_model
+from ..loss import DINOLoss, iBOTPatchLoss, KoLeoLoss
+from ..models import build_model_from_cfg
+from ..layers import DINOHead
+from ..utils.utils import has_batchnorms
+from ..utils.param_groups import get_params_groups_with_decay, fuse_params_groups
+from ..fsdp import get_fsdp_wrapper, ShardedGradScaler, get_fsdp_modules, reshard_fsdp_model
 
-from chexfound.models.vision_transformer import BlockChunk
+from ..models.vision_transformer import BlockChunk
 
 
 try:

--- a/chexfound/train/train.py
+++ b/chexfound/train/train.py
@@ -12,16 +12,16 @@ from functools import partial
 from fvcore.common.checkpoint import Checkpointer, PeriodicCheckpointer
 import torch
 
-from chexfound.data import SamplerType, make_data_loader, make_dataset
-from chexfound.data import collate_data_and_cast, DataAugmentationDINO, MaskingGenerator
-import chexfound.distributed as distributed
-from chexfound.fsdp import FSDPCheckpointer
-from chexfound.logging import MetricLogger
-from chexfound.utils.config import setup
-from chexfound.utils.utils import CosineScheduler
+from ..data import SamplerType, make_data_loader, make_dataset
+from ..data import collate_data_and_cast, DataAugmentationDINO, MaskingGenerator
+from .. import distributed
+from ..fsdp import FSDPCheckpointer
+from ..logging import MetricLogger
+from ..utils.config import setup
+from ..utils.utils import CosineScheduler
 
-from chexfound.train.ssl_meta_arch import SSLMetaArch
-from chexfound import utils
+from .ssl_meta_arch import SSLMetaArch
+from .. import utils
 
 
 torch.backends.cuda.matmul.allow_tf32 = True  # PyTorch 1.12 sets this to False by default

--- a/chexfound/utils/config.py
+++ b/chexfound/utils/config.py
@@ -9,10 +9,10 @@ import os
 
 from omegaconf import OmegaConf
 
-import chexfound.distributed as distributed
-from chexfound.logging import setup_logging
-from chexfound.utils import utils
-from chexfound.configs import dinov2_default_config
+from .. import distributed
+from ..logging import setup_logging
+from . import utils
+from ..configs import dinov2_default_config
 
 
 logger = logging.getLogger("chexfound")


### PR DESCRIPTION
## Summary
- convert package-internal absolute imports to use relative paths across data, eval, training, and utilities modules

## Testing
- python -m compileall chexfound

------
https://chatgpt.com/codex/tasks/task_e_68cfe75a9e2c8324aa09344f9f7e2403